### PR TITLE
Enable line wrapping in the description editor

### DIFF
--- a/addons/kanban_tasks/view/details/details.tscn
+++ b/addons/kanban_tasks/view/details/details.tscn
@@ -32,3 +32,4 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
+wrap_mode = 1


### PR DESCRIPTION
This PR enables line wrapping in the task description editor so that long descriptions automatically wrap to the next line. This stops long lines from going out of view, requiring horizontal scrolling.