### PR TITLE
Fix for previously created task step completion not being saved

### DIFF
--- a/addons/kanban_tasks/data/board.gd
+++ b/addons/kanban_tasks/data/board.gd
@@ -233,6 +233,10 @@ func __add_task(task: __Task, uuid: String = "") -> String:
 
 	if __tasks.has(uuid):
 		push_warning("The uuid " + uuid + ' is already used. A new one will be generated for the task "' + task.title + '".')
+		
+	for step in task.steps:
+		if not step.changed.is_connected(__notify_changed):
+			step.changed.connect(__notify_changed)
 
 	if uuid == "":
 		uuid = __UUID.v4()


### PR DESCRIPTION
Currently, if you create a task with steps, then close Godot, then re-open, completing a step will not save to the json file.

This fixes https://github.com/HolonProduction/godot_kanban_tasks/issues/19

so now if you complete a step, it'll save as expected