### PR TITLE
Resolved Crashes During New Task Creation with Deleted or Missing Category Data

### DIFF
--- a/addons/kanban_tasks/plugin_singleton/singletons.gd
+++ b/addons/kanban_tasks/plugin_singleton/singletons.gd
@@ -9,6 +9,9 @@ const HOLDER_NAME: String = "PluginSingletons"
 static func instance_of(p_script: Script, requester: Node) -> Variant:
 	var holder: Node = requester.get_tree().get_root().get_node_or_null(HOLDER_NAME)
 
+	if requester.get_tree() == null:
+		return
+
 	if not is_instance_valid(holder):
 		holder = Node.new()
 		holder.name = HOLDER_NAME

--- a/addons/kanban_tasks/view/task/task.gd
+++ b/addons/kanban_tasks/view/task/task.gd
@@ -321,6 +321,9 @@ func __update_tooltip() -> void:
 func __apply_filter() -> void:
 	var ctx: __EditContext = __Singletons.instance_of(__EditContext, self)
 
+	if ctx == null:
+		return
+
 	if not ctx.filter or ctx.filter.text.length() == 0:
 		show()
 		return


### PR DESCRIPTION
Addressed the crash occurring during the creation of a new task when the save file lacks data for a task with the same category.


https://github.com/HolonProduction/godot_kanban_tasks/assets/122761839/ea5e9d32-4fc0-4ddc-a992-54aacee9224f

